### PR TITLE
Initialize OpenAI client via env

### DIFF
--- a/ego-plant-app/server.js
+++ b/ego-plant-app/server.js
@@ -1,9 +1,12 @@
 const express = require('express');
 const path = require('path');
 const Sentiment = require('sentiment');
+const { OpenAI } = require('openai');
 
 const app = express();
 const sentiment = new Sentiment();
+const openaiKey = process.env.OPENAI_API_KEY;
+const openai = openaiKey ? new OpenAI({ apiKey: openaiKey }) : null;
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
## Summary
- initialize OpenAI client in the server using `process.env.OPENAI_API_KEY`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68537bb3bb50832e8c15ea45a074fffd